### PR TITLE
Refactor logo assets for reusable variants

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,7 +66,7 @@
     <header class="site-header" aria-label="Main">
       <div class="container nav">
         <a href="/" class="brand" aria-label="B&S Floor Supply">
-          <img src="https://bsglobalservices.com/newweb/assets/logo.png" alt="B&S Floor Supply logo" />
+          <span class="logo-bs logo-bs--full" role="img" aria-label="B&S Floor Supply logo"></span>
           <span>B&S Floor Supply</span>
         </a>
         <nav aria-label="Primary">
@@ -88,7 +88,7 @@
 
       <!-- Brand strip with logo -->
       <div class="brand-hero">
-        <img src="https://bsglobalservices.com/newweb/assets/logo.png" alt="B&S Floor Supply logo" />
+        <span class="logo-bs logo-bs--full" role="img" aria-label="B&S Floor Supply logo"></span>
         <div class="brand-hero-copy">
           <strong>B&S Floor Supply</strong>
           <small>Waterproof LVP • Installation of Laminate, Vinyl & Hardwood</small>
@@ -435,7 +435,7 @@
     <div class="container fgrid">
       <div>
         <div class="brand" style="margin-bottom:.6rem">
-          <img src="https://bsglobalservices.com/newweb/assets/logo.png" alt="B&S Floor Supply logo" />
+          <span class="logo-bs logo-bs--white" role="img" aria-label="B&S Floor Supply logo"></span>
           <span>B&S Floor Supply</span>
         </div>
         <p id="footer_pitch">Waterproof LVP — plus installation of laminate, vinyl and hardwood. Bilingual team. Fast, neat, reliable.</p>

--- a/services/flooring-install/index.html
+++ b/services/flooring-install/index.html
@@ -25,7 +25,7 @@
   <header class="site-header" aria-label="Main">
     <div class="container nav">
       <a href="/" class="brand" aria-label="B&S Floor Supply">
-        <img src="https://bsglobalservices.com/newweb/assets/logo.png" alt="B&S Floor Supply logo" />
+        <span class="logo-bs logo-bs--full" role="img" aria-label="B&S Floor Supply logo"></span>
         <span>B&S Floor Supply</span>
       </a>
       <nav aria-label="Primary">

--- a/store/index.html
+++ b/store/index.html
@@ -22,7 +22,7 @@
   <header class="site-header" aria-label="Main">
     <div class="container nav">
       <a href="/" class="brand" aria-label="B&S Floor Supply">
-        <img src="https://bsglobalservices.com/newweb/assets/logo.png" alt="B&S Floor Supply logo" />
+        <span class="logo-bs logo-bs--full" role="img" aria-label="B&S Floor Supply logo"></span>
         <span>B&S Floor Supply</span>
       </a>
       <nav aria-label="Primary">

--- a/style.css
+++ b/style.css
@@ -9,6 +9,16 @@
     img{max-width:100%;display:block}
       .container{width:min(var(--container), 92%);margin-inline:auto}
 
+    /* Logo variants */
+    .logo-bs{display:inline-block;background-size:contain;background-repeat:no-repeat;background-position:center}
+    .brand .logo-bs{width:42px;height:42px}
+    .brand-hero .logo-bs{width:48px;height:48px}
+    .logo-bs--full{background-image:url('images/logo_bs_full.png')}
+    .logo-bs--white{background-image:url('images/logo_bs_white.png')}
+    .logo-bs--black{background-image:url('images/logo_bs_black.png')}
+    .logo-bs--wine{background-image:url('images/logo_bs_wine.png')}
+    .logo-bs--brown{background-image:url('images/logo_bs_brown.png')}
+
     /* Top banner bilingual */
     .topbar{background:#111;color:#ddd;font-size:.9rem}
     .topbar .wrap{display:flex;align-items:center;justify-content:space-between;gap:.6rem;padding:.45rem 0}
@@ -20,7 +30,7 @@
     header.site-header{position:sticky;top:0;z-index:50;background:#fff;border-bottom:1px solid #eee}
     .nav{display:flex;align-items:center;justify-content:space-between;padding:.8rem 0;gap:1rem}
     .brand{display:flex;align-items:center;gap:.7rem}
-    .brand img{width:42px;height:42px;object-fit:contain}
+    /* Logo text spacing handled by .brand span */
     .brand span{font-family:Montserrat, sans-serif;font-weight:700;letter-spacing:.3px}
     .menu{display:flex;gap:1.2rem;align-items:center}
     .menu a{font-weight:500}
@@ -64,7 +74,7 @@
       padding:.6rem .8rem; margin:.8rem 0;
       box-shadow:0 4px 12px rgba(0,0,0,.04);
     }
-    .brand-hero img{ width:48px; height:48px; object-fit:contain }
+    /* Brand strip logo handled by .brand-hero .logo-bs */
     .brand-hero-copy strong{ font-family:Montserrat, sans-serif }
     .brand-hero-copy small{ color:#555; display:block; margin-top:2px }
 


### PR DESCRIPTION
## Summary
- add reusable CSS classes for logo variants
- update index, store, and flooring-install pages to use local logo assets

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0c5e6e68832a90f308c3acf84a80