### PR TITLE
feat: add background sliders and unify contact form

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,9 +66,8 @@
     <header class="site-header" aria-label="Main">
       <div class="container nav">
         <a href="#" class="brand" aria-label="B&S Floor Supply">
-          <span class="logo-bs logo-bs--full" role="img" aria-label="B&S Floor Supply logo"></span>
-          <span>B&S Floor Supply</span>
-        </a>
+        <span class="logo-bs logo-bs--full" role="img" aria-label="B&S Floor Supply logo"></span>
+      </a>
         <nav aria-label="Primary">
         <button class="burger" aria-label="Toggle menu" aria-controls="menu" aria-expanded="false" id="burger">
           <span></span><span></span><span></span>
@@ -83,6 +82,9 @@
 
   <!-- Hero with form -->
   <main id="top" class="container hero">
+    <div class="bg-slider" style="--bg-opacity:.25">
+      <div class="slide active" style="background-image:url('images/sliders/index.jpg')"></div>
+    </div>
     <div>
       <span class="badge" id="badge-hero">Waterproof LVP • Orlando, FL</span>
 
@@ -473,6 +475,20 @@
     burger?.addEventListener('click', ()=>{
       const open = menu.classList.toggle('show');
       burger.setAttribute('aria-expanded', open ? 'true' : 'false');
+    });
+
+    // Background slider
+    document.querySelectorAll('.bg-slider').forEach(slider => {
+      const slides = slider.querySelectorAll('.slide');
+      let i = 0;
+      slides[0]?.classList.add('active');
+      if (slides.length > 1) {
+        setInterval(() => {
+          slides[i].classList.remove('active');
+          i = (i + 1) % slides.length;
+          slides[i].classList.add('active');
+        }, 5000);
+      }
     });
 
     // Dynamic year

--- a/services/flooring-install/index.html
+++ b/services/flooring-install/index.html
@@ -26,7 +26,6 @@
     <div class="container nav">
       <a href="../../" class="brand" aria-label="B&S Floor Supply">
         <span class="logo-bs logo-bs--full" role="img" aria-label="B&S Floor Supply logo"></span>
-        <span>B&S Floor Supply</span>
       </a>
       <nav aria-label="Primary">
         <button class="burger" aria-label="Toggle menu" aria-controls="menu" aria-expanded="false" id="burger">
@@ -53,6 +52,9 @@
 
 <main>
   <div class="container hero">
+    <div class="bg-slider" style="--bg-opacity:.25">
+      <div class="slide active" style="background-image:url('../../images/sliders/flooring_install.png')"></div>
+    </div>
     <div class="hero-copy">
       <span class="badge">Bilingual EN/ES · Orlando, FL</span>
       <h1>Professional Flooring Installation</h1>
@@ -272,57 +274,71 @@
     </div>
   </section>
 
-  <!-- Dark CTA -->
-  <section id="contact" class="section sec-dark">
+  <!-- Contact / CTA (beige) -->
+  <section id="contact" class="sec--light">
     <div class="container">
-      <h2>Ready to get a quote?</h2>
-      <div class="grid" style="grid-template-columns:1.1fr .9fr;gap:var(--gap)">
-        <div class="panel">
-          <h3>Chat on WhatsApp</h3>
-          <p class="lead">Bilingual assistance (EN/ES). Extended hours.</p>
-          <a class="btn btn-primary" href="https://wa.me/16892968515?text=Hi%2C%20I%20want%20a%20flooring%20installation%20quote" target="_blank" rel="noopener">Open WhatsApp</a>
+      <div class="sec-head">
+        <div>
+          <div class="eyebrow" data-i18n="ey_contact">Let’s get your estimate</div>
+          <h2 data-i18n="h_contact">Contact & free estimate</h2>
         </div>
-        <div class="panel">
-          <form action="/send-quote" method="post" aria-label="Detailed quote form">
-            <div class="row">
-              <div>
-                <label for="name2">Name</label>
-                <input id="name2" name="name" type="text" required>
-              </div>
-              <div>
-                <label for="email2">Email</label>
-                <input id="email2" name="email" type="email" required>
-              </div>
+        <a href="https://wa.me/16892968515?text=Hi%20B%26S%20Floor%20Supply%2C%20I'd%20like%20a%20free%20estimate." class="pill" id="cta-wa-pill" target="_blank" rel="noopener" data-i18n="cta_whatsapp">Chat on WhatsApp</a>
+      </div>
+      <div class="contact" style="display:grid;grid-template-columns:1.1fr .9fr;gap:1rem">
+        <form class="form" id="lead-form-bottom" action="/lead.php" method="POST" aria-labelledby="contact-bottom">
+          <div class="row">
+            <div>
+              <label for="name-bottom" data-i18n="form_name">Full name</label>
+              <input id="name-bottom" name="name" placeholder="Your name" required />
             </div>
-            <div class="row">
-              <div>
-                <label for="phone2">Phone</label>
-                <input id="phone2" name="phone" type="tel" required>
-              </div>
-              <div>
-                <label for="city2">City</label>
-                <input id="city2" name="city" type="text" placeholder="Orlando / Kissimmee / St. Cloud">
-              </div>
+            <div>
+              <label for="phone-bottom" data-i18n="form_phone">Phone / WhatsApp</label>
+              <input id="phone-bottom" name="phone" placeholder="+1 (689) 296-8515" required />
             </div>
-            <div class="row">
-              <div>
-                <label for="floor2">Floor type</label>
-                <input id="floor2" name="floor" type="text" placeholder="LVP, ceramic, laminate, wood">
-              </div>
-              <div>
-                <label for="sqft2">Approx. SQFT</label>
-                <input id="sqft2" name="sqft" type="number" min="0" step="1" placeholder="e.g., 650">
-              </div>
+          </div>
+          <div class="row">
+            <div>
+              <label for="email-bottom">Email</label>
+              <input id="email-bottom" type="email" name="email" placeholder="info@globalservices.com" required />
             </div>
-            <div class="row-1">
-              <div>
-                <label for="msg2">Notes</label>
-                <textarea id="msg2" name="msg" placeholder="Rooms, timelines, removal, subfloor condition…"></textarea>
-              </div>
+            <div>
+              <label for="service-bottom" data-i18n="form_service">Service</label>
+              <select id="service-bottom" name="service">
+                <option value="lvp" data-i18n="opt_lvp">Waterproof LVP – supply & install</option>
+                <option value="install" data-i18n="opt_install">Installation only (Laminate / Vinyl / Hardwood)</option>
+                <option value="other" data-i18n="opt_other">Other flooring</option>
+              </select>
             </div>
-            <button class="btn btn-primary" type="submit">Request my quote</button>
-          </form>
-        </div>
+          </div>
+          <div class="row-1">
+            <div>
+              <label for="message-bottom" data-i18n="form_details">Project details</label>
+              <textarea id="message-bottom" name="message" placeholder="Area size, rooms, preferred tone…"></textarea>
+            </div>
+          </div>
+          <input type="hidden" name="form_name" value="B&S – Web Lead (bottom)" />
+          <input type="hidden" name="source" value="website_services" />
+          <p class="note" data-i18n="form_note">By sending, you agree to be contacted via WhatsApp, phone or email.</p>
+          <div class="hero-cta">
+            <button type="submit" class="btn btn-primary" id="send-btn-bottom" data-i18n="cta_send">Send request</button>
+            <a class="btn btn-ghost" href="https://wa.me/16892968515?text=Hi%20B%26S%20Floor%20Supply%2C%20I%20need%20a%20quote." target="_blank" rel="noopener" id="cta-wa-form" data-i18n="cta_whatsapp">WhatsApp now</a>
+          </div>
+          <p id="form-status-bottom" class="note hide" aria-live="polite"></p>
+        </form>
+
+        <!-- Info -->
+        <aside class="card">
+          <h3 data-i18n="info_t">Contact info</h3>
+          <p><strong>Phone (WhatsApp):</strong> <a href="https://wa.me/16892968515" target="_blank" rel="noopener">+1 (689) 296-8515</a></p>
+          <p><strong>Alt. phone:</strong> +1 (407) 225-1284</p>
+          <p><strong>Email:</strong> <a href="mailto:info@globalservices.com">info@globalservices.com</a></p>
+          <p><strong>Service area:</strong> Orlando, FL</p>
+          <p>
+            <a href="https://www.instagram.com/bsfloorsupply" target="_blank" rel="noopener">Instagram</a><br />
+            <a href="https://www.facebook.com/BSGlobalServices" target="_blank" rel="noopener">Facebook</a>
+          </p>
+          <p><small data-i18n="info_es">¿Prefere español? También atendemos en español.</small></p>
+        </aside>
       </div>
     </div>
   </section>
@@ -335,6 +351,20 @@
     burger?.addEventListener('click', () => {
       const open = menu.classList.toggle('show');
       burger.setAttribute('aria-expanded', open ? 'true' : 'false');
+    });
+
+    // Background slider
+    document.querySelectorAll('.bg-slider').forEach(slider => {
+      const slides = slider.querySelectorAll('.slide');
+      let i = 0;
+      slides[0]?.classList.add('active');
+      if (slides.length > 1) {
+        setInterval(() => {
+          slides[i].classList.remove('active');
+          i = (i + 1) % slides.length;
+          slides[i].classList.add('active');
+        }, 5000);
+      }
     });
   </script>
 

--- a/style.css
+++ b/style.css
@@ -11,7 +11,7 @@
 
     /* Logo variants */
     .logo-bs{display:inline-block;background-size:contain;background-repeat:no-repeat;background-position:center}
-    .brand .logo-bs{width:42px;height:42px}
+    .brand .logo-bs{width:140px;aspect-ratio:2667/1372;height:auto}
     .brand-hero .logo-bs{width:48px;height:48px}
     .logo-bs--full{background-image:url('images/logo_bs_full.png')}
     .logo-bs--white{background-image:url('images/logo_bs_white.png')}
@@ -29,9 +29,7 @@
     /* Header */
     header.site-header{position:sticky;top:0;z-index:50;background:#fff;border-bottom:1px solid #eee}
     .nav{display:flex;align-items:center;justify-content:space-between;padding:.8rem 0;gap:1rem}
-    .brand{display:flex;align-items:center;gap:.7rem}
-    /* Logo text spacing handled by .brand span */
-    .brand span{font-family:Montserrat, sans-serif;font-weight:700;letter-spacing:.3px}
+    .brand{display:flex;align-items:center}
     .menu{display:flex;gap:1.2rem;align-items:center}
     .menu a{font-weight:500}
     .cta-wa{background:var(--burgundy);color:#fff;padding:.6rem .9rem;border-radius:12px;font-weight:600;border:2px solid var(--burgundy)}
@@ -45,7 +43,7 @@
     }
 
     /* Hero with form */
-    .hero{display:grid;grid-template-columns:1.1fr .9fr;align-items:start;gap:1.2rem;padding:2.2rem 0}
+    .hero{display:grid;grid-template-columns:1.1fr .9fr;align-items:start;gap:1.2rem;padding:2.2rem 0;position:relative}
     .badge{display:inline-flex;align-items:center;gap:.5rem;background:rgba(90,42,46,.08);color:#5A2A2E;padding:.35rem .65rem;border-radius:999px;font-size:.85rem;font-weight:600}
     .h1{font-family:Montserrat, sans-serif;font-weight:700;font-size:clamp(1.8rem, 3.5vw, 3rem);line-height:1.1;margin:1rem 0 .5rem}
     .lead{font-size:1.05rem;color:#333;max-width:58ch}
@@ -66,6 +64,11 @@
     textarea{min-height:110px;resize:vertical}
     .note{font-size:.85rem;color:#555}
     @media (max-width: 980px){ .hero{grid-template-columns:1fr} .hero > .form{position:static} }
+
+    /* Background slider */
+    .bg-slider{position:absolute;inset:0;z-index:-1;overflow:hidden;pointer-events:none}
+    .bg-slider .slide{position:absolute;inset:0;background-size:cover;background-position:center;opacity:0;transition:opacity 1s}
+    .bg-slider .slide.active{opacity:var(--bg-opacity,.25)}
 
     /* Brand strip inside hero */
     .brand-hero{


### PR DESCRIPTION
## Summary
- enlarge header logo and remove brand text
- add configurable background sliders to index and flooring-install pages
- reuse home "Contact & free estimate" section on flooring-install page

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf14c217c0832a977470c8f3ffef6a