### PR TITLE
Implement reusable email template and copy sending

### DIFF
--- a/email-template.php
+++ b/email-template.php
@@ -1,0 +1,12 @@
+<html>
+  <body>
+    <h2>New lead from <?php echo htmlspecialchars($formName); ?></h2>
+    <ul>
+      <li><strong>Name:</strong> <?php echo htmlspecialchars($name); ?></li>
+      <li><strong>Phone:</strong> <?php echo htmlspecialchars($phone); ?></li>
+      <li><strong>Email:</strong> <?php echo htmlspecialchars($email); ?></li>
+      <li><strong>Service:</strong> <?php echo htmlspecialchars($service); ?></li>
+    </ul>
+    <p><?php echo nl2br(htmlspecialchars($message)); ?></p>
+  </body>
+</html>

--- a/lead.php
+++ b/lead.php
@@ -1,0 +1,44 @@
+<?php
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    exit('Method Not Allowed');
+}
+
+$name    = $_POST['name'] ?? '';
+$phone   = $_POST['phone'] ?? '';
+$email   = $_POST['email'] ?? '';
+$service = $_POST['service'] ?? '';
+$message = $_POST['message'] ?? '';
+$formName = $_POST['form_name'] ?? 'Lead';
+
+$subject = 'New lead from B&S website';
+$subjectCopy = 'Copy of your request to B&S Floor Supply';
+
+ob_start();
+include __DIR__ . '/email-template.php';
+$body = ob_get_clean();
+
+function sendMailWithHeaders($to, $subject, $body, $replyTo)
+{
+    $headers = "From: info@bsglobalservices.com\r\n";
+    if (!empty($replyTo)) {
+        $headers .= "Reply-To: $replyTo\r\n";
+    }
+    $headers .= 'X-Mailer: PHP/' . phpversion() . "\r\n";
+    $headers .= "Content-Type: text/html; charset=UTF-8\r\n";
+
+    return mail($to, $subject, $body, $headers);
+}
+
+function sendCopy($to, $subjectCopy, $body)
+{
+    return sendMailWithHeaders($to, $subjectCopy, $body, 'info@bsglobalservices.com');
+}
+
+$sent = sendMailWithHeaders('info@bsglobalservices.com', $subject, $body, $email);
+
+if ($sent && !empty($email)) {
+    sendCopy($email, $subjectCopy, $body);
+}
+
+echo $sent ? 'OK' : 'ERROR';


### PR DESCRIPTION
## Summary
- Add PHP script `lead.php` to send emails with fixed sender, user Reply-To, and extra headers
- Extract reusable HTML body into `email-template.php`
- Provide separate function to send user copy of submission

## Testing
- `php -l lead.php`
- `php -l email-template.php`


------
https://chatgpt.com/codex/tasks/task_e_68c04df9224c832a8edb46a314806d2d