### PR TITLE
Create FormData before disabling form elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -567,10 +567,11 @@
         trackEvent('lead_submit', {form_name: formName});
         status?.classList.remove('hide');
         if(status) status.textContent = 'Sending your request…';
-        if(form) Array.from(form.elements).forEach(el=>el.disabled=true);
+        const formData = new FormData(form);
+        Array.from(form.elements).forEach(el=>el.disabled=true);
         if(sendBtn) sendBtn.textContent = 'Sending…';
         try{
-          const res = await fetch(form.action || 'lead.php', {method:'POST', body:new FormData(form)});
+          const res = await fetch(form.action || 'lead.php', {method:'POST', body:formData});
           const data = await res.json();
           if(status) status.textContent = data.data || 'Request sent.';
           if(res.ok && data.code === '01') form.reset();


### PR DESCRIPTION
## Summary
- Create `FormData` before disabling form elements in `bindForm`
- Submit fetch requests using the stored `FormData`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c07f49d0a0832aaee13a05532fc6ef