### PR TITLE
Fix bind param count after adding city field

### DIFF
--- a/lead.php
+++ b/lead.php
@@ -85,7 +85,7 @@ if (!$stmt) {
     exit;
 }
 
-$stmt->bind_param('sssssss', $name, $email, $phone, $service, $message, $formName, $source, $city);
+$stmt->bind_param('ssssssss', $name, $email, $phone, $service, $message, $formName, $source, $city);
 if (!$stmt->execute()) {
     echo json_encode(['code' => '02', 'data' => 'A error occurred while sending the form. Please try again later.']);
     $stmt->close();


### PR DESCRIPTION
## Summary
- Ensure database insert binds all eight parameters after adding the `city` field

## Testing
- `php -l lead.php`
- `php -l email-template.php`


------
https://chatgpt.com/codex/tasks/task_e_68c094e4a5a8832a852a2782297b4ce7