### PR TITLE
Align product carousel and cart components side-by-side

### DIFF
--- a/store/cart.php
+++ b/store/cart.php
@@ -16,14 +16,16 @@ $contact_source = 'website_store';
 <?php include $base.'includes/header.php'; ?>
 <main class="container" style="padding-bottom:3vw;">
   <h1>Your cart</h1>
-  <div id="cart-items"></div>
-  <p id="cart-empty" class="note">Your cart is empty.</p>
-  <hr />
-  <form id="cart-form" action="<?=$base?>lead.php" method="POST">
-    <div class="row">
-      <div>
-        <label for="name-cart">Full name</label>
-        <input id="name-cart" name="name" required />
+  <div class="cart-layout">
+    <div class="cart-items">
+      <div id="cart-items"></div>
+      <p id="cart-empty" class="note">Your cart is empty.</p>
+    </div>
+    <form id="cart-form" action="<?=$base?>lead.php" method="POST" class="cart-form">
+      <div class="row">
+        <div>
+          <label for="name-cart">Full name</label>
+          <input id="name-cart" name="name" required />
       </div>
       <div>
         <label for="phone-cart">Phone / WhatsApp</label>
@@ -50,7 +52,8 @@ $contact_source = 'website_store';
       <button type="submit" class="btn btn-primary" id="send-cart">Send order</button>
     </div>
     <p id="cart-status" class="note" aria-live="polite"></p>
-  </form>
+    </form>
+  </div>
 </main>
 <?php include $base.'includes/footer.php'; ?>
 <script>

--- a/store/product.php
+++ b/store/product.php
@@ -44,51 +44,55 @@ $contact_source = 'website_store';
         <span class="pill"><?= htmlspecialchars($product['name']) ?></span>
     </div>
     <h1></h1>
-    <div class="slider">
-      <div>
-        <?php foreach($selected as $i => $img): ?>
-          <img src="../<?= $img ?>" alt="<?= htmlspecialchars($product['name']) ?>" class="<?= $i===0 ? 'active' : '' ?>">
-        <?php endforeach; ?>
-        <button class="prev" type="button">Prev</button>
-        <button class="next" type="button">Next</button>
-        <?php if(!empty($product['promo'])): ?>
-          <div class="store-promo"><span><?= htmlspecialchars($product['promo']) ?></span></div>
-        <?php endif; ?>
+    <div class="product-top">
+      <div class="slider">
+        <div>
+          <?php foreach($selected as $i => $img): ?>
+            <img src="../<?= $img ?>" alt="<?= htmlspecialchars($product['name']) ?>" class="<?= $i===0 ? 'active' : '' ?>">
+          <?php endforeach; ?>
+          <button class="prev" type="button">Prev</button>
+          <button class="next" type="button">Next</button>
+          <?php if(!empty($product['promo'])): ?>
+            <div class="store-promo"><span><?= htmlspecialchars($product['promo']) ?></span></div>
+          <?php endif; ?>
+        </div>
       </div>
-    </div>
-    <?php
-      $priceSqft = isset($product['price_sqft']) && $product['price_sqft'] !== null ? '$'.number_format($product['price_sqft'],2) : '';
-      $priceBoxNum = $product['price_box'] ?? null;
-      if ($priceBoxNum === null && isset($product['price_sqft'], $product['sqft_per_box'])) {
-        $priceBoxNum = $product['price_sqft'] * $product['sqft_per_box'];
-      }
-      $priceBox = $priceBoxNum !== null ? '$'.number_format($priceBoxNum,2) : '';
-    ?>
-    <div class="store-price">
-      <?php if($priceSqft): ?>
-        <div><b><?= $priceSqft ?></b><span class="store-per">/sqft</span></div>
-      <?php else: ?>
-        <div><b>Call for price</b></div>
-      <?php endif; ?>
-      <?php if($priceBox): ?>
-        <div><span class="store-per">≈ <?= $priceBox ?> / box</span></div>
-      <?php endif; ?>
-    </div>
+      <div class="product-cart">
+        <?php
+          $priceSqft = isset($product['price_sqft']) && $product['price_sqft'] !== null ? '$'.number_format($product['price_sqft'],2) : '';
+          $priceBoxNum = $product['price_box'] ?? null;
+          if ($priceBoxNum === null && isset($product['price_sqft'], $product['sqft_per_box'])) {
+            $priceBoxNum = $product['price_sqft'] * $product['sqft_per_box'];
+          }
+          $priceBox = $priceBoxNum !== null ? '$'.number_format($priceBoxNum,2) : '';
+        ?>
+        <div class="store-price">
+          <?php if($priceSqft): ?>
+            <div><b><?= $priceSqft ?></b><span class="store-per">/sqft</span></div>
+          <?php else: ?>
+            <div><b>Call for price</b></div>
+          <?php endif; ?>
+          <?php if($priceBox): ?>
+            <div><span class="store-per">≈ <?= $priceBox ?> / box</span></div>
+          <?php endif; ?>
+        </div>
 
-    <div id="calc" class="calc" style="margin:1rem 0;">
-      <h3>Material calculator</h3>
-      <div class="row">
-        <label>Length (ft)<input type="number" id="calcLen" step="0.1"></label>
-        <label>Width (ft)<input type="number" id="calcWid" step="0.1"></label>
+        <div id="calc" class="calc" style="margin:1rem 0;">
+          <h3>Material calculator</h3>
+          <div class="row">
+            <label>Length (ft)<input type="number" id="calcLen" step="0.1"></label>
+            <label>Width (ft)<input type="number" id="calcWid" step="0.1"></label>
+          </div>
+          <div class="row">
+            <span>or</span>
+          </div>
+          <div class="row">
+            <label>Boxes<input type="number" id="calcBoxes" min="1" value="1"></label>
+          </div>
+          <p id="calcSummary" class="note"></p>
+          <button type="button" id="addToCart" class="btn btn-primary">Add to cart</button>
+        </div>
       </div>
-      <div class="row">
-        <span>or</span>
-      </div>
-      <div class="row">
-        <label>Boxes<input type="number" id="calcBoxes" min="1" value="1"></label>
-      </div>
-      <p id="calcSummary" class="note"></p>
-      <button type="button" id="addToCart" class="btn btn-primary">Add to cart</button>
     </div>
 
     <div class="tabs">

--- a/style.css
+++ b/style.css
@@ -297,12 +297,20 @@
     }
     /* Product detail */
     .slider{position:relative;margin:auto;aspect-ratio:16/10;overflow:hidden;border-radius:10px; background-color: var(--dark);}
-    .slider>div{position:relative; width: 70%; height:100%; margin: auto;}
+    .slider>div{position:relative;width:100%;height:100%;margin:auto;}
     .slider img{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;opacity:0;transition:opacity .5s ease}
     .slider img.active{opacity:1}
-    .slider button{position:absolute;top:50%;transform:translateY(-50%);background:rgba(0,0,0,.5);color:#fff;border:none;padding:.5rem 1rem;cursor:pointer}
-    .slider .prev{left:10px}
-    .slider .next{right:10px}
+      .slider button{position:absolute;top:50%;transform:translateY(-50%);background:rgba(0,0,0,.5);color:#fff;border:none;padding:.5rem 1rem;cursor:pointer}
+      .slider .prev{left:10px}
+      .slider .next{right:10px}
+
+      .product-top{display:flex;flex-direction:column;gap:1rem}
+      .product-top .slider,.product-top .product-cart{width:100%}
+      @media (min-width:981px){
+        .product-top{flex-direction:row;align-items:flex-start}
+        .product-top .slider{width:60%}
+        .product-top .product-cart{width:40%}
+      }
 
     .tabs{display:flex;margin-top:1rem;border-bottom:1px solid #eadfcd}
     .tabs button{flex:1;padding:.6rem;background:#f4ede4;border:none;cursor:pointer;font-weight:700;color:var(--burgundy)}
@@ -345,4 +353,17 @@
     .store-price{display:flex;gap:10px;align-items:baseline;margin:6px 0 8px}
     .store-price b{font-size:1.1rem}
     .store-price .store-per{color:#777}
-    .store-cta{display:flex;gap:8px;flex-wrap:wrap;margin-top:auto;padding:0 14px 14px}
+      .store-cta{display:flex;gap:8px;flex-wrap:wrap;margin-top:auto;padding:0 14px 14px}
+
+      .cart-layout{display:flex;flex-direction:column;gap:1rem}
+      .cart-items,.cart-form{width:100%}
+      .cart-item{display:flex;align-items:center;gap:.5rem;margin-bottom:.5rem}
+      .cart-item span{flex:1}
+      .cart-item .qty{width:60px}
+      .cart-item .remove{background:none;border:none;color:var(--burgundy);cursor:pointer}
+      @media (min-width:981px){
+        .cart-layout{flex-direction:row;align-items:flex-start}
+        .cart-form{width:40%;order:1}
+        .cart-items{width:60%;order:2}
+      }
+


### PR DESCRIPTION
## Summary
- Display product carousel and material calculator side-by-side at 60/40 split on desktop
- Organize cart page into form and product list columns for clearer layout
- Expand slider width for better image presentation

## Testing
- `php -l store/product.php`
- `php -l store/cart.php`


------
https://chatgpt.com/codex/tasks/task_e_68c70f29786c832a8cd9c6d599cd1074