### PR TITLE
Integrate catalog & schedule section into main site

### DIFF
--- a/includes/footer.php
+++ b/includes/footer.php
@@ -18,6 +18,7 @@ $base = $base ?? '';
         <a href="<?=$base?>#portfolio" data-i18n="nav_use">Portfolio / Proyects</a><br/>
         <a href="<?=$base?>#reviews" data-i18n="nav_reviews">Reviews</a><br/>
         <a href="<?=$base?>#faq" data-i18n="nav_faq">FAQ</a><br/>
+        <a href="<?=$base?>register/">Catalog &amp; Schedule</a><br/>
         <a href="<?=$base?>terms.html">Terms & Conditions</a>
       </nav>
     </div>

--- a/includes/header.php
+++ b/includes/header.php
@@ -33,6 +33,11 @@ $active = $active ?? '';
         <?php else: ?>
           <a href="<?=$base?>store/" role="menuitem">Store</a>
         <?php endif; ?>
+        <?php if ($active === 'register'): ?>
+          <a href="#" role="menuitem">Catalog &amp; Schedule</a>
+        <?php else: ?>
+          <a href="<?=$base?>register/" role="menuitem">Catalog &amp; Schedule</a>
+        <?php endif; ?>
         <a href="<?=$base?>store/cart.php" role="menuitem">Cart (<span id="cart-count">0</span>)</a>
       </div>
     </nav>

--- a/register/index.php
+++ b/register/index.php
@@ -1,3 +1,7 @@
+<?php
+$base = '../';
+$active = 'register';
+?>
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -6,14 +10,12 @@
 <title>B&S Floor Supply — Catalog & Schedule</title>
 <meta name="description" content="Request the Waterproof LVP catalog, a quick estimate, or schedule an appointment with B&S Floor Supply.">
 <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@700;800&family=Poppins:wght@300;400;500;600&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="<?=$base?>style.css" />
 <style>
   :root{--burgundy:#5A2A2E;--gold:#CDA349;--beige:#F5EBDD;--gray:#D9D9D9;--white:#FFFFFF;--ink:#1d1d1f;--shadow:0 10px 30px rgba(0,0,0,.12)}
   *{box-sizing:border-box}
   html,body{margin:0;background:#fff;color:var(--ink);font-family:Poppins,system-ui,-apple-system,"Segoe UI",Roboto,Arial,sans-serif;line-height:1.55}
   .wrap{width:min(1000px,92%);margin-inline:auto}
-  header{border-bottom:1px solid #eee;background:#fff;position:sticky;top:0;z-index:5}
-  header .h{display:flex;justify-content:space-between;align-items:center;padding:12px 0}
-  .brand{font-family:Montserrat,sans-serif;font-weight:800;color:var(--burgundy)}
   .hero{background:linear-gradient(180deg,#F5EBDD 0,#fff 100%);border-bottom:1px solid #eadfcd}
   .hero .wrap{padding:clamp(28px,7vw,72px) 0}
   h1{font-family:Montserrat,sans-serif;font-weight:800;color:var(--burgundy);margin:0 0 8px;font-size:clamp(26px,3.6vw,44px)}
@@ -35,7 +37,6 @@
   .consent{display:flex;align-items:flex-start;gap:10px}
   .consent input{margin-top:4px}
   .note{background:#fff8ea;border:1px solid #f0e0b9;color:#5a4a1f;padding:10px;border-radius:12px;font-size:.9rem}
-  footer{padding:24px 0;color:#777;border-top:1px solid #eee;margin-top:28px}
 
   /* Scheduler */
   .slots{display:grid;grid-template-columns:repeat(3,1fr);gap:8px;margin-top:8px}
@@ -58,11 +59,7 @@ window.SLOT_MINUTES=60;
 </script>
 </head>
 <body>
-<header>
-  <div class="wrap h">
-    <div class="brand">B&amp;S Floor Supply</div>
-  </div>
-</header>
+<?php include $base.'includes/header.php'; ?>
 
 <section class="hero">
   <div class="wrap">
@@ -186,9 +183,8 @@ window.SLOT_MINUTES=60;
   </div>
 </main>
 
-<footer class="wrap">
-  © B&amp;S Floor Supply — Waterproof LVP Specialists
-</footer>
+<?php include $base.'includes/reviews.php'; ?>
+<?php include $base.'includes/footer.php'; ?>
 
 <script>
 (function(){


### PR DESCRIPTION
## Summary
- Convert standalone catalog/schedule HTML into PHP page with shared header, reviews, and footer
- Expose Catalog & Schedule section in main navigation and footer

## Testing
- `php -l register/index.php`
- `php -l includes/header.php`
- `php -l includes/footer.php`


------
https://chatgpt.com/codex/tasks/task_e_68c712f47d00832a84591f24a3464aba