### PR TITLE
Style material calculator like existing forms

### DIFF
--- a/store/product.php
+++ b/store/product.php
@@ -77,20 +77,25 @@ $contact_source = 'website_store';
           <?php endif; ?>
         </div>
 
-        <div id="calc" class="calc" style="margin:1rem 0;">
+        <div id="calc" class="calc">
           <h3>Material calculator</h3>
-          <div class="row">
-            <label>Length (ft)<input type="number" id="calcLen" step="0.1"></label>
-            <label>Width (ft)<input type="number" id="calcWid" step="0.1"></label>
-          </div>
-          <div class="row">
-            <span>or</span>
-          </div>
-          <div class="row">
-            <label>Boxes<input type="number" id="calcBoxes" min="1" value="1"></label>
-          </div>
-          <p id="calcSummary" class="note"></p>
-          <button type="button" id="addToCart" class="btn btn-primary">Add to cart</button>
+          <form id="calcForm">
+            <label>
+              Length (ft)
+              <input type="number" id="calcLen" step="0.1">
+            </label>
+            <label>
+              Width (ft)
+              <input type="number" id="calcWid" step="0.1">
+            </label>
+            <div class="full or">or</div>
+            <label class="full">
+              Boxes
+              <input type="number" id="calcBoxes" min="1" value="1">
+            </label>
+            <p id="calcSummary" class="note full"></p>
+            <button type="button" id="addToCart" class="btn btn-primary full">Add to cart</button>
+          </form>
         </div>
       </div>
     </div>

--- a/style.css
+++ b/style.css
@@ -312,6 +312,15 @@
         .product-top .product-cart{width:40%}
       }
 
+      .calc{margin:1rem 0}
+      .calc form{display:grid;grid-template-columns:1fr 1fr;gap:12px}
+      .calc label{display:flex;flex-direction:column;font-size:.95rem;color:#333;gap:6px}
+      .calc input{padding:.7rem .8rem;border:1px solid #ddd;border-radius:12px;font:inherit}
+      .calc .full{grid-column:1/-1}
+      .calc .or{text-align:center;color:#777}
+      .calc button{justify-self:start}
+      @media(max-width:540px){.calc form{grid-template-columns:1fr}}
+
     .tabs{display:flex;margin-top:1rem;border-bottom:1px solid #eadfcd}
     .tabs button{flex:1;padding:.6rem;background:#f4ede4;border:none;cursor:pointer;font-weight:700;color:var(--burgundy)}
     .tabs button.active{background:var(--burgundy);color:#fff}


### PR DESCRIPTION
## Summary
- Rebuild material calculator markup as a form with labeled fields and full-width controls
- Add calculator-specific CSS for grid layout, consistent input styling, and responsiveness

## Testing
- `php -l store/product.php`


------
https://chatgpt.com/codex/tasks/task_e_68c73860bba8832aa5709781ef501e53