### PR TITLE
Hide cart link when empty and auto-redirect after clearing

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -38,7 +38,7 @@ $active = $active ?? '';
         <?php else: ?>
           <a href="<?=$base?>register/" role="menuitem">Catalog &amp; Schedule</a>
         <?php endif; ?>
-        <a href="<?=$base?>store/cart.php" role="menuitem">Cart (<span id="cart-count">0</span>)</a>
+        <a id="cart-link" href="<?=$base?>store/cart.php" role="menuitem" hidden>Cart (<span id="cart-count">0</span>)</a>
       </div>
     </nav>
   </div>
@@ -46,8 +46,11 @@ $active = $active ?? '';
 <script src="<?=$base?>store/cart.js"></script>
 <script>
   function updateCartCount(){
+    const count = cart.getCount();
     const el = document.getElementById('cart-count');
-    if(el) el.textContent = cart.getCount();
+    if(el) el.textContent = count;
+    const link = document.getElementById('cart-link');
+    if(link) link.hidden = count <= 0;
   }
   document.addEventListener('cartchange', updateCartCount);
   updateCartCount();

--- a/store/cart.php
+++ b/store/cart.php
@@ -62,6 +62,7 @@ $contact_source = 'website_store';
 <?php include $base.'includes/footer.php'; ?>
 <script>
 const PRODUCTS = <?= json_encode($products) ?>;
+let previousCount = cart.getItems().length;
 function formatCurrency(value){
   if(!Number.isFinite(value) || value <= 0){
     return '';
@@ -80,6 +81,12 @@ function renderCart(){
     if(summary){
       summary.textContent = '';
     }
+    if(previousCount > 0){
+      previousCount = 0;
+      window.location.href = 'index.php';
+      return;
+    }
+    previousCount = 0;
     return;
   }
   empty.style.display = 'none';
@@ -126,6 +133,7 @@ function renderCart(){
     }, 0);
     summary.textContent = `Subtotal (${items.length} item${items.length !== 1 ? 's' : ''}): ${formatCurrency(total) || 'Call for price'}`;
   }
+  previousCount = items.length;
   container.querySelectorAll('.qty').forEach(input=>{
     input.addEventListener('change', ()=>{
       const wrapper = input.closest('.cart-item');


### PR DESCRIPTION
## Summary
- hide the cart navigation link until there is at least one item in the cart
- redirect shoppers back to the store when the cart is cleared while viewing the cart page

## Testing
- php -l includes/header.php
- php -l store/cart.php

------
https://chatgpt.com/codex/tasks/task_e_68cc896fbff4832a9ef588307f61c384